### PR TITLE
Added XBUS_MODE_B to serial rx configuration.

### DIFF
--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -148,7 +148,8 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             'SPEKTRUM2048',
             'SBUS',
             'SUMD',
-            'SUMH'
+            'SUMH',
+            'XBUS_MODE_B'
         ];
 
         var serialRX_e = $('select.serialRX');


### PR DESCRIPTION
As the XBus support were merged into the cleanflight master, I also suggest that we add a setting for this in the configurator tab in the cleanflight-configurator tool. I added this with underscore, please let me know if this is ok or not. 
Edit: While reviewing the changes I realized that my editor (geany) had added a new-line (at the end of the file) in the source file. Please let me know if you do not want this.
Best regards
Stefan