### PR TITLE
Servo Channel Tab Configuration Update - supports 4-16 Channels for servo tilt mapping.

### DIFF
--- a/tabs/servos.html
+++ b/tabs/servos.html
@@ -4,19 +4,14 @@
         <div class="title" i18n="servosChangeDirection"></div>
         <table class="fields">
             <tr class="main">
-                <th width="20%" i18n="servosName"></th>
-                <th i18n="servosMid"></th>
-                <th i18n="servosMin"></th>
-                <th i18n="servosMax"></th>
-                <th style="width: 40px">CH-1</th>
-                <th style="width: 40px">CH-2</th>
-                <th style="width: 40px">CH-3</th>
-                <th style="width: 40px">CH-4</th>
-                <th style="width: 40px">AUX1</th>
-                <th style="width: 40px">AUX2</th>
-                <th style="width: 40px">AUX3</th>
-                <th style="width: 40px">AUX4</th>
-                <th style="width: 200px" i18n="servosDirection"></th>
+                <th width="200px" i18n="servosName"></th>
+                <th style="width: 120px" i18n="servosMid"></th>
+                <th style="width: 120px" i18n="servosMin"></th>
+                <th style="width: 120px" i18n="servosMax"></th>
+                <th style="width: 40px">CH1</th>
+                <th style="width: 40px">CH2</th>
+                <th style="width: 40px">CH3</th>
+                <th style="width: 40px">CH4</th>
             </tr>
         </table>
         <div class="direction_wrapper">

--- a/tabs/servos.js
+++ b/tabs/servos.js
@@ -39,21 +39,21 @@ TABS.servos.initialize = function (callback) {
 
     function process_html() {
 
-		var servoCheckbox = '';
-		var servoHeader = '';
-		for (var i = 0; i < RC.active_channels-4; i++) {
-			servoHeader = servoHeader + '\
+        var servoCheckbox = '';
+        var servoHeader = '';
+        for (var i = 0; i < RC.active_channels-4; i++) {
+            servoHeader = servoHeader + '\
                 <th >A' + (i+1) + '</th>\
-			';
-		}
-		servoHeader = servoHeader + '<th style="width: 200px" i18n="servosDirection"></th>';
+            ';
+        }
+        servoHeader = servoHeader + '<th style="width: 200px" i18n="servosDirection"></th>';
 
-		for (var i = 0; i < RC.active_channels; i++) {
-			servoCheckbox = servoCheckbox + '\
+        for (var i = 0; i < RC.active_channels; i++) {
+            servoCheckbox = servoCheckbox + '\
                 <td class="channel"><input type="checkbox"/></td>\
-			';
-		}
-		
+            ';
+        }
+        
 
 
         $('div.tab-servos table.fields tr.main').append(servoHeader);
@@ -83,28 +83,28 @@ TABS.servos.initialize = function (callback) {
         }
 
         function process_servos(name, alternate, obj, directions) {
-		
+        
             $('div.supported_wrapper').show();
 
 
-			
+            
             $('div.tab-servos table.fields').append('\
                 <tr> \
                     <td style="text-align: center">' + name + '</td>\
                     <td class="middle"><input type="number" min="1000" max="2000" value="' + SERVO_CONFIG[obj].middle + '" /></td>\
                     <td class="min"><input type="number" min="1000" max="2000" value="' + SERVO_CONFIG[obj].min +'" /></td>\
                     <td class="max"><input type="number" min="1000" max="2000" value="' + SERVO_CONFIG[obj].max +'" /></td>\
-					' + servoCheckbox + '\
+                    ' + servoCheckbox + '\
                     <td class="direction">\
                         <input class="first" type="checkbox"/><span class="name">' + name + '</span>\
-						<input class="second" type="checkbox"/><span class="alternate">' + alternate + '</span>\
+                        <input class="second" type="checkbox"/><span class="alternate">' + alternate + '</span>\
                     </td>\
                 </tr> \
             ');
 
-			
+            
 
-			        // translate to user-selected language
+                    // translate to user-selected language
         localize();
 
             $('div.tab-servos table.fields tr:last td.channel input').eq(SERVO_CONFIG[obj].indexOfChannelToForward).prop('checked', true);

--- a/tabs/servos.js
+++ b/tabs/servos.js
@@ -97,6 +97,7 @@ TABS.servos.initialize = function (callback) {
 					' + servoCheckbox + '\
                     <td class="direction">\
                         <input class="first" type="checkbox"/><span class="name">' + name + '</span>\
+						<input class="second" type="checkbox"/><span class="alternate">' + alternate + '</span>\
                     </td>\
                 </tr> \
             ');

--- a/tabs/servos.js
+++ b/tabs/servos.js
@@ -20,7 +20,11 @@ TABS.servos.initialize = function (callback) {
     }
 
     function get_channel_forwarding_data() {
-        MSP.send_message(MSP_codes.MSP_CHANNEL_FORWARDING, false, false, get_boxnames_data);
+        MSP.send_message(MSP_codes.MSP_CHANNEL_FORWARDING, false, false, get_rc_data);
+    }
+
+   function get_rc_data() {
+        MSP.send_message(MSP_codes.MSP_RC, false, false, get_boxnames_data);
     }
 
     function get_boxnames_data() {
@@ -34,8 +38,25 @@ TABS.servos.initialize = function (callback) {
     MSP.send_message(MSP_codes.MSP_IDENT, false, false, get_servo_conf_data);
 
     function process_html() {
-        // translate to user-selected language
-        localize();
+
+		var servoCheckbox = '';
+		var servoHeader = '';
+		for (var i = 0; i < RC.active_channels-4; i++) {
+			servoHeader = servoHeader + '\
+                <th >A' + (i+1) + '</th>\
+			';
+		}
+		servoHeader = servoHeader + '<th style="width: 200px" i18n="servosDirection"></th>';
+
+		for (var i = 0; i < RC.active_channels; i++) {
+			servoCheckbox = servoCheckbox + '\
+                <td class="channel"><input type="checkbox"/></td>\
+			';
+		}
+		
+
+
+        $('div.tab-servos table.fields tr.main').append(servoHeader);
 
         function process_directions(name, obj, bitpos) {
             $('div.direction_wrapper').show();
@@ -62,28 +83,28 @@ TABS.servos.initialize = function (callback) {
         }
 
         function process_servos(name, alternate, obj, directions) {
+		
             $('div.supported_wrapper').show();
 
+
+			
             $('div.tab-servos table.fields').append('\
                 <tr> \
                     <td style="text-align: center">' + name + '</td>\
                     <td class="middle"><input type="number" min="1000" max="2000" value="' + SERVO_CONFIG[obj].middle + '" /></td>\
                     <td class="min"><input type="number" min="1000" max="2000" value="' + SERVO_CONFIG[obj].min +'" /></td>\
                     <td class="max"><input type="number" min="1000" max="2000" value="' + SERVO_CONFIG[obj].max +'" /></td>\
-                    <td class="channel"><input type="checkbox"/></td>\
-                    <td class="channel"><input type="checkbox"/></td>\
-                    <td class="channel"><input type="checkbox"/></td>\
-                    <td class="channel"><input type="checkbox"/></td>\
-                    <td class="channel"><input type="checkbox"/></td>\
-                    <td class="channel"><input type="checkbox"/></td>\
-                    <td class="channel"><input type="checkbox"/></td>\
-                    <td class="channel"><input type="checkbox"/></td>\
+					' + servoCheckbox + '\
                     <td class="direction">\
                         <input class="first" type="checkbox"/><span class="name">' + name + '</span>\
-                        <input class="second" type="checkbox"/><span class="alternate">' + alternate + '</span>\
                     </td>\
                 </tr> \
             ');
+
+			
+
+			        // translate to user-selected language
+        localize();
 
             $('div.tab-servos table.fields tr:last td.channel input').eq(SERVO_CONFIG[obj].indexOfChannelToForward).prop('checked', true);
 


### PR DESCRIPTION
**!!!Limited testing has been done, so please check it out before considering merging!!!**

Added support for 16 channel receivers in servo control for tilt/gimbal. (4 standard channels + any number of active channels).
Number of Aux channels rendered = total channel count active on receiver - 4 ( allowing for 4 standard control channels )

i.e 8 Channels  = ch1, ch2, ch3, ch4, a1, a2, a3, a4
i.e 16 Channels  = ch1, ch2, ch3, ch4, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12

Now you can utilise any of the additional channels to control the servos.  Initially done for servo tilt, but appears to be active for other servo modes as well, although these are untested.

I don't believe any firmware updates are required as its only a channel mapping.  Looking at the servo screens when armed, servos 7-8 move correctly based on selected channel/  Have no real hardware available yet to check.

See below for a rendering of the updated screen layout ( and channel name truncation ).

![servo_16](https://cloud.githubusercontent.com/assets/5808106/5793249/08921c02-9f35-11e4-99da-5048b2958bea.png)

PS - Never written any javascript / chrome extensions so could have made a few gotchas - and sorry for any code layout issues etc.  
PPS - First time using GIT for this stuff as well, so hopefully all is well with the workflow.

**Please be kind**