### PR TITLE
Allow negative current scales and allow an offset between 0 and 3.3V

### DIFF
--- a/js/msp.js
+++ b/js/msp.js
@@ -482,7 +482,7 @@ var MSP = {
                 BF_CONFIG.board_align_roll = data.getInt16(6, 1);
                 BF_CONFIG.board_align_pitch = data.getInt16(8, 1);
                 BF_CONFIG.board_align_yaw = data.getInt16(10, 1);
-                BF_CONFIG.currentscale = data.getUint16(12, 1);
+                BF_CONFIG.currentscale = data.getInt16(12, 1);
                 BF_CONFIG.currentoffset = data.getUint16(14, 1);
                 break;
             case MSP_codes.MSP_SET_BF_CONFIG:

--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -198,13 +198,13 @@
         </table>        
         <div class="number">
             <label>
-                <input type="number" name="currentscale" step="1" min="1" max="1000" />
+                <input type="number" name="currentscale" step="1" min="-1000" max="1000" />
                 <span i18n="configurationCurrentScale"></span>
             </label>
         </div>
         <div class="number">
             <label>
-                <input type="number" name="currentoffset" step="1" min="1" max="1000" />
+                <input type="number" name="currentoffset" step="1" min="0" max="3300" />
                 <span i18n="configurationCurrentOffset"></span>
             </label>
         </div>


### PR DESCRIPTION
This are the needed changes for https://github.com/cleanflight/cleanflight/pull/413

- allow current scales from -1000 to 1000
- read scale as int instead uint
- allow offset from 0 to 3300 (before offset 0 was not possible)