### PR TITLE
Enhanced PID Tuning tab to set TPA Breakpoint

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -573,6 +573,9 @@
     "pidTuningTPA": {
         "message": "TPA"
     },
+    "pidTuningTPABreakPoint": {
+        "message": "TPA Breakpoint"
+    },
     "pidTuningButtonSave": {
         "message": "Save"
     },

--- a/changelog.html
+++ b/changelog.html
@@ -1,4 +1,4 @@
-<span>2015.03.11 - 0.62.2 - cleanflight</span>
+<span>2015.03.11 - 0.63.0 - cleanflight</span>
 <p>
     - PID Tuning tab allows TPA Breakpoint changes - Requires 1.8.0 firmware.<br />
     - Corrected Artificial Horizon Pitch/Roll views.<br />

--- a/changelog.html
+++ b/changelog.html
@@ -1,3 +1,9 @@
+<span>2015.03.11 - 0.62.2 - cleanflight</span>
+<p>
+    - PID Tuning tab allows TPA Breakpoint changes - Requires 1.8.0 firmware.<br />
+    - Corrected Artificial Horizon Pitch/Roll views.<br />
+    - Changed logging time stamp to include date stamp.<br />
+</p>
 <span>2015.03.03 - 0.63 - cleanflight</span>
 <p>
     - Support new firmware 1.8 serial port configuration.<br />

--- a/js/data_storage.js
+++ b/js/data_storage.js
@@ -69,7 +69,8 @@ var RC_tuning = {
     yaw_rate:        0,
     dynamic_THR_PID: 0,
     throttle_MID:    0,
-    throttle_EXPO:   0
+    throttle_EXPO:   0,
+    dynamic_THR_breakpoint: 0
 };
 
 var AUX_CONFIG = [];

--- a/js/gui.js
+++ b/js/gui.js
@@ -207,11 +207,20 @@ GUI_control.prototype.timeout_kill_all = function () {
 GUI_control.prototype.log = function (message) {
     var command_log = $('div#log');
     var d = new Date();
+    var year = d.getFullYear();
+    var month = ((d.getMonth() < 9) ? '0' + (d.getMonth() + 1) : (d.getMonth() + 1));
+    var date =  ((d.getDate() < 10) ? '0' + d.getDate() : d.getDate());
     var time = ((d.getHours() < 10) ? '0' + d.getHours(): d.getHours())
-        + ':' + ((d.getMinutes() < 10) ? '0' + d.getMinutes(): d.getMinutes())
-        + ':' + ((d.getSeconds() < 10) ? '0' + d.getSeconds(): d.getSeconds());
+         + ':' + ((d.getMinutes() < 10) ? '0' + d.getMinutes(): d.getMinutes())
+         + ':' + ((d.getSeconds() < 10) ? '0' + d.getSeconds(): d.getSeconds());
 
-    $('div.wrapper', command_log).append('<p>' + time + ' -- ' + message + '</p>');
+    var formattedDate = "{0}-{1}-{2} {3}".format(
+                                year,
+                                month,
+                                date,
+                                ' @ ' + time
+                            );
+    $('div.wrapper', command_log).append('<p>' + formattedDate + ' -- ' + message + '</p>');
     command_log.scrollTop($('div.wrapper', command_log).height());
 };
 

--- a/js/libraries/jquery.flightindicators.js
+++ b/js/libraries/jquery.flightindicators.js
@@ -65,6 +65,7 @@
 
 		// Private methods
 		function _setRoll(roll){
+			roll *= -1;
 			placeholder.each(function(){
 				$(this).find('div.instrument.attitude div.roll').css('transform', 'rotate('+roll+'deg)');
 			});
@@ -75,7 +76,7 @@
 			if(pitch>constants.pitch_bound){pitch = constants.pitch_bound;}
 			else if(pitch<-constants.pitch_bound){pitch = -constants.pitch_bound;}
 			placeholder.each(function(){
-				$(this).find('div.instrument.attitude div.roll div.pitch').css('top', pitch*0.7 + '%');
+				$(this).find('div.instrument.attitude div.roll div.pitch').css('top', -pitch*0.7 + '%');
 			});
 		}
 

--- a/js/msp.js
+++ b/js/msp.js
@@ -295,6 +295,7 @@ var MSP = {
                 RC_tuning.dynamic_THR_PID = parseFloat((data.getUint8(4) / 100).toFixed(2));
                 RC_tuning.throttle_MID = parseFloat((data.getUint8(5) / 100).toFixed(2));
                 RC_tuning.throttle_EXPO = parseFloat((data.getUint8(6) / 100).toFixed(2));
+                RC_tuning.dynamic_THR_breakpoint = parseInt(data.getUint16(7, 1));
                 break;
             case MSP_codes.MSP_PID:
                 // PID data arrived, we need to scale it and save to appropriate bank / array
@@ -917,6 +918,8 @@ MSP.crunch = function (code) {
             buffer.push(parseInt(RC_tuning.dynamic_THR_PID * 100));
             buffer.push(parseInt(RC_tuning.throttle_MID * 100));
             buffer.push(parseInt(RC_tuning.throttle_EXPO * 100));
+            buffer.push(lowByte(RC_tuning.dynamic_THR_breakpoint));
+            buffer.push(highByte(RC_tuning.dynamic_THR_breakpoint));
             break;
         // Disabled, cleanflight does not use MSP_SET_BOX.
         /*

--- a/tabs/pid_tuning.css
+++ b/tabs/pid_tuning.css
@@ -90,6 +90,11 @@
     float: right;
     width: calc(40% - 10px); /* - ( "virtual" margin) */
 }
+.tab-pid_tuning .rate-tpa .tpa{
+    float: right;
+    border: 1px solid #ADDFAC; /*THEME CHANGE HERE*/
+    width: calc(100% - 10px); /* - ( "virtual" margin) */    
+}
 .tab-pid_tuning .buttons {
     width: calc(100% - 20px);
 

--- a/tabs/pid_tuning.html
+++ b/tabs/pid_tuning.html
@@ -84,11 +84,13 @@
                 <th i18n="pidTuningRollPitchRate"></th>
                 <th i18n="pidTuningYawRate"></th>
                 <th i18n="pidTuningTPA"></th>
+                <th i18n="pidTuningTPABreakPoint" class="tpa"></th>
             </tr>
             <tr>
                 <td><input type="number" name="roll-pitch" step="0.01" min="0" max="2.55"/></td>
                 <td><input type="number" name="yaw" step="0.01" min="0" max="2.55"/></td>
                 <td><input type="number" name="tpa" step="0.01" min="0" max="2.55"/></td>
+                <td><input type="number" name="tpa-breakpoint" step="10" min="1000" max="2000" /></td>
             </tr>
         </table>
     </form>

--- a/tabs/pid_tuning.js
+++ b/tabs/pid_tuning.js
@@ -175,6 +175,7 @@ TABS.pid_tuning.initialize = function (callback) {
         $('.rate-tpa input[name="roll-pitch"]').val(RC_tuning.roll_pitch_rate.toFixed(2));
         $('.rate-tpa input[name="yaw"]').val(RC_tuning.yaw_rate.toFixed(2));
         $('.rate-tpa input[name="tpa"]').val(RC_tuning.dynamic_THR_PID.toFixed(2));
+        $('.rate-tpa input[name="tpa-breakpoint"]').val(RC_tuning.dynamic_THR_breakpoint);
     }
 
     function form_to_pid_and_rc() {
@@ -233,6 +234,7 @@ TABS.pid_tuning.initialize = function (callback) {
         RC_tuning.roll_pitch_rate = parseFloat($('.rate-tpa input[name="roll-pitch"]').val());
         RC_tuning.yaw_rate = parseFloat($('.rate-tpa input[name="yaw"]').val());
         RC_tuning.dynamic_THR_PID = parseFloat($('.rate-tpa input[name="tpa"]').val());
+        RC_tuning.dynamic_THR_breakpoint = parseInt($('.rate-tpa input[name="tpa-breakpoint"]').val());
     }
 
     function process_html() {


### PR DESCRIPTION
Added TPA Breakpoint param change feature to PID tuning tab.
cleanflight/cleanflight-configurator#59
The above enhancement relies on the updated serial_msp.c:
cleanflight/cleanflight#601
Changed logging time stamp to include date stamp, for better tracking and comparison of screen shots.
cleanflight/cleanflight-configurator#103
Fixed artificial horizon Roll/Pitch views.
cleanflight/cleanflight-configurator#123