### PR TITLE
Update firmware_flasher.js - hide Release Info Div

### DIFF
--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -263,6 +263,7 @@ TABS.firmware_flasher.initialize = function (callback) {
             if (!$(this).hasClass('locked')) {
                 if (!GUI.connect_lock) { // button disabled while flashing is in progress
                     if (parsed_hex != false) {
+                        $('div.release_info').slideUp();//hide it so we can see progress bar in action
                         if (String($('div#port-picker #port').val()) != 'DFU') {
                             if (String($('div#port-picker #port').val()) != '0') {
                                 var options = {},


### PR DESCRIPTION
firmware_flasher tab is user unfriendly, it slides down and things may get confusing for the first time user.
Propose to hide the Release Info Div, when flash firmware button is clicked, so progress bar comes into view for visual cue.