### PR TITLE
Update roll/pitch/yaw rate limits to match CF's limits

### DIFF
--- a/tabs/pid_tuning.html
+++ b/tabs/pid_tuning.html
@@ -94,8 +94,8 @@
                     <td class="roll-pitch" ><input type="number" name="roll-pitch" step="0.01" min="0" max="1.00"/></td>
                     <td class="roll" ><input type="number" name="roll" step="0.01" min="0" max="1.00"/></td>
                     <td class="pitch" ><input type="number" name="pitch" step="0.01" min="0" max="1.00"/></td>
-                    <td><input type="number" name="yaw" step="0.01" min="0" max="1.00"/></td>
-                    <td><input type="number" name="tpa" step="0.01" min="0" max="2.55"/></td>
+                    <td><input type="number" name="yaw" step="0.01" min="0" max="2.55"/></td>
+                    <td><input type="number" name="tpa" step="0.01" min="0" max="1.00"/></td>
                     <td class="tpa-breakpoint"><input type="number" name="tpa-breakpoint" step="10" min="1000" max="2000" /></td>
                 </tr>
             </tbody>

--- a/tabs/pid_tuning.html
+++ b/tabs/pid_tuning.html
@@ -91,10 +91,10 @@
             </thead>
             <tbody>
                 <tr>
-                    <td class="roll-pitch" ><input type="number" name="roll-pitch" step="0.01" min="0" max="2.55"/></td>
-                    <td class="roll" ><input type="number" name="roll" step="0.01" min="0" max="2.55"/></td>
-                    <td class="pitch" ><input type="number" name="pitch" step="0.01" min="0" max="2.55"/></td>
-                    <td><input type="number" name="yaw" step="0.01" min="0" max="2.55"/></td>
+                    <td class="roll-pitch" ><input type="number" name="roll-pitch" step="0.01" min="0" max="1.00"/></td>
+                    <td class="roll" ><input type="number" name="roll" step="0.01" min="0" max="1.00"/></td>
+                    <td class="pitch" ><input type="number" name="pitch" step="0.01" min="0" max="1.00"/></td>
+                    <td><input type="number" name="yaw" step="0.01" min="0" max="1.00"/></td>
                     <td><input type="number" name="tpa" step="0.01" min="0" max="2.55"/></td>
                     <td class="tpa-breakpoint"><input type="number" name="tpa-breakpoint" step="10" min="1000" max="2000" /></td>
                 </tr>


### PR DESCRIPTION
Previously r/p/y was allowed to be set to values higher than could be set using the CLI, and roll/pitch > 1.0 is meaningless (it causes the PID loop to actively destabilise flight).