### PR TITLE
Added MAVLink telemetry

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -551,6 +551,9 @@
     "portsFunction_TELEMETRY_SMARTPORT": {
         "message": "SmartPort"
     },
+    "portsFunction_TELEMETRY_MAVLINK": {
+        "message": "MAVLink"
+    },
     "portsFunction_RX_SERIAL": {
         "message": "Serial RX"
     },

--- a/js/msp.js
+++ b/js/msp.js
@@ -118,7 +118,7 @@ var MSP = {
     ],
     
     serialPortFunctions: // in LSB bit order 
-        ['MSP', 'GPS', 'TELEMETRY_FRSKY', 'TELEMETRY_HOTT', 'TELEMETRY_MSP', 'TELEMETRY_SMARTPORT', 'RX_SERIAL', 'BLACKBOX'],
+        ['MSP', 'GPS', 'TELEMETRY_FRSKY', 'TELEMETRY_HOTT', 'TELEMETRY_MSP', 'TELEMETRY_SMARTPORT', 'RX_SERIAL', 'BLACKBOX', 'TELEMETRY_MAVLINK'],
 
     read: function (readInfo) {
         var data = new Uint8Array(readInfo.data);

--- a/tabs/ports.js
+++ b/tabs/ports.js
@@ -14,6 +14,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
          {name: 'TELEMETRY_HOTT',       groups: ['telemetry'], sharableWith: ['msp'], notSharableWith: ['blackbox'], maxPorts: 1},
          {name: 'TELEMETRY_MSP',        groups: ['telemetry'], sharableWith: ['msp'], notSharableWith: ['blackbox'], maxPorts: 1},
          {name: 'TELEMETRY_SMARTPORT',  groups: ['telemetry'], maxPorts: 1},
+         {name: 'TELEMETRY_MAVLINK',    groups: ['telemetry'], sharableWith: ['msp'], notSharableWith: ['blackbox'], maxPorts: 1},
          {name: 'RX_SERIAL',            groups: ['rx'], maxPorts: 1},
          {name: 'BLACKBOX',             groups: ['logging', 'blackbox'], sharableWith: ['msp'], notSharableWith: ['telemetry'], maxPorts: 1},
     ];


### PR DESCRIPTION
This PR complements cleanflight/cleanflight#806 and adds configurator function to set telemetry to MAVLink without CLI.