### PR TITLE
Proof of concept of a way to display PID in a "one-line"

### DIFF
--- a/tabs/pid_tuning.html
+++ b/tabs/pid_tuning.html
@@ -77,6 +77,10 @@
                 <td></td>
                 <td><input type="number" name="p" step="0.1" min="0" max="25.5"/></td>
             </tr>
+            <tr class="QUICKCOPY"><!-- 9 -->
+            	<td>PID "one-line"</td>
+                <td colspan="3"><input type="text" name="pid-copy-and-paste"/></td>
+            </tr>
         </table>
         <table class="rate-tpa">
             <thead>

--- a/tabs/pid_tuning.js
+++ b/tabs/pid_tuning.js
@@ -51,19 +51,16 @@ TABS.pid_tuning.initialize = function (callback) {
                 	data = PIDs[0][i++].toFixed(1);
                     $(this).val(data);
                     cp += data + ':';
-                    // $(this).val(PIDs[0][i++].toFixed(1));
                     break;
                 case 1:
                 	data = PIDs[0][i++].toFixed(3);
                     $(this).val(data);
                     cp += data + ':';
-                    // $(this).val(PIDs[0][i++].toFixed(3));
                     break;
                 case 2:
                 	data = PIDs[0][i++].toFixed(0);
                     $(this).val(data);
                     cp += data;
-                    // $(this).val(PIDs[0][i++].toFixed(0));
                     break;
             }
         });
@@ -76,19 +73,16 @@ TABS.pid_tuning.initialize = function (callback) {
                 	data = PIDs[1][i++].toFixed(1);
                     $(this).val(data);
                     cp += data + ':';
-                    // $(this).val(PIDs[1][i++].toFixed(1));
                     break;
                 case 1:
-                	data = PIDs[0][i++].toFixed(3);
+                	data = PIDs[1][i++].toFixed(3);
                     $(this).val(data);
                     cp += data + ':';
-                    //$(this).val(PIDs[1][i++].toFixed(3));
                     break;
                 case 2:
-                	data = PIDs[0][i++].toFixed(0);
+                	data = PIDs[1][i++].toFixed(0);
                     $(this).val(data);
                     cp += data;
-                    // $(this).val(PIDs[1][i++].toFixed(0));
                     break;
             }
         });
@@ -101,19 +95,16 @@ TABS.pid_tuning.initialize = function (callback) {
                 	data = PIDs[2][i++].toFixed(1);
                     $(this).val(data);
                     cp += data + ':';
-                    // $(this).val(PIDs[2][i++].toFixed(1));
                     break;
                 case 1:
-                	data = PIDs[0][i++].toFixed(3);
+                	data = PIDs[2][i++].toFixed(3);
                     $(this).val(data);
                     cp += data + ':';
-                    // $(this).val(PIDs[2][i++].toFixed(3));
                     break;
                 case 2:
-                	data = PIDs[0][i++].toFixed(0);
+                	data = PIDs[2][i++].toFixed(0);
                     $(this).val(data);
                     cp += data;
-                    //$(this).val(PIDs[2][i++].toFixed(0));
                     break;
             }
         });
@@ -212,7 +203,6 @@ TABS.pid_tuning.initialize = function (callback) {
         $('.rate-tpa input[name="tpa-breakpoint"]').val(RC_tuning.dynamic_THR_breakpoint);
         
         $('.pid_tuning .QUICKCOPY input').val(cp);
-        // $('.pid-copy input[name="pid-copy-and-paste"]').html('test');
     }
 
     function form_to_pid_and_rc() {

--- a/tabs/pid_tuning.js
+++ b/tabs/pid_tuning.js
@@ -40,48 +40,80 @@ TABS.pid_tuning.initialize = function (callback) {
     MSP.send_message(MSP_codes.MSP_STATUS, false, false, get_pid_controller);
 
     function pid_and_rc_to_form() {
+    	var cp = 'R:';
         // Fill in the data from PIDs array
         var i = 0;
+        var data = '';
+        
         $('.pid_tuning .ROLL input').each(function () {
             switch (i) {
                 case 0:
-                    $(this).val(PIDs[0][i++].toFixed(1));
+                	data = PIDs[0][i++].toFixed(1);
+                    $(this).val(data);
+                    cp += data + ':';
+                    // $(this).val(PIDs[0][i++].toFixed(1));
                     break;
                 case 1:
-                    $(this).val(PIDs[0][i++].toFixed(3));
+                	data = PIDs[0][i++].toFixed(3);
+                    $(this).val(data);
+                    cp += data + ':';
+                    // $(this).val(PIDs[0][i++].toFixed(3));
                     break;
                 case 2:
-                    $(this).val(PIDs[0][i++].toFixed(0));
+                	data = PIDs[0][i++].toFixed(0);
+                    $(this).val(data);
+                    cp += data;
+                    // $(this).val(PIDs[0][i++].toFixed(0));
                     break;
             }
         });
 
+		cp += ' P:';
         i = 0;
         $('.pid_tuning .PITCH input').each(function () {
             switch (i) {
                 case 0:
-                    $(this).val(PIDs[1][i++].toFixed(1));
+                	data = PIDs[1][i++].toFixed(1);
+                    $(this).val(data);
+                    cp += data + ':';
+                    // $(this).val(PIDs[1][i++].toFixed(1));
                     break;
                 case 1:
-                    $(this).val(PIDs[1][i++].toFixed(3));
+                	data = PIDs[0][i++].toFixed(3);
+                    $(this).val(data);
+                    cp += data + ':';
+                    //$(this).val(PIDs[1][i++].toFixed(3));
                     break;
                 case 2:
-                    $(this).val(PIDs[1][i++].toFixed(0));
+                	data = PIDs[0][i++].toFixed(0);
+                    $(this).val(data);
+                    cp += data;
+                    // $(this).val(PIDs[1][i++].toFixed(0));
                     break;
             }
         });
 
+		cp += ' Y:';
         i = 0;
         $('.pid_tuning .YAW input').each(function () {
             switch (i) {
                 case 0:
-                    $(this).val(PIDs[2][i++].toFixed(1));
+                	data = PIDs[2][i++].toFixed(1);
+                    $(this).val(data);
+                    cp += data + ':';
+                    // $(this).val(PIDs[2][i++].toFixed(1));
                     break;
                 case 1:
-                    $(this).val(PIDs[2][i++].toFixed(3));
+                	data = PIDs[0][i++].toFixed(3);
+                    $(this).val(data);
+                    cp += data + ':';
+                    // $(this).val(PIDs[2][i++].toFixed(3));
                     break;
                 case 2:
-                    $(this).val(PIDs[2][i++].toFixed(0));
+                	data = PIDs[0][i++].toFixed(0);
+                    $(this).val(data);
+                    cp += data;
+                    //$(this).val(PIDs[2][i++].toFixed(0));
                     break;
             }
         });
@@ -178,6 +210,9 @@ TABS.pid_tuning.initialize = function (callback) {
         $('.rate-tpa input[name="yaw"]').val(RC_tuning.yaw_rate.toFixed(2));
         $('.rate-tpa input[name="tpa"]').val(RC_tuning.dynamic_THR_PID.toFixed(2));
         $('.rate-tpa input[name="tpa-breakpoint"]').val(RC_tuning.dynamic_THR_breakpoint);
+        
+        $('.pid_tuning .QUICKCOPY input').val(cp);
+        // $('.pid-copy input[name="pid-copy-and-paste"]').html('test');
     }
 
     function form_to_pid_and_rc() {


### PR DESCRIPTION
This is more of a Proof of Concept then a PR

What i like to add is a way to quickly communicate my current PID. The usage has come to me while configuring PID using bluetooth while being able to still be in irc. Since what we often talk about are the PID - only PID are needed in this. Using screenshots is to large of a use-case in order to make it smooth.

The second reason for this proof of concept is finding a unified nomenclature to talk about PID. Instead of every time read different ways of writing it a convention of this should be created. My suggestion is just a start for a bigger picture but here is a starting point.

R:4.0:0.030:23 P:4.0:0.030:23 Y:8.5:0.030:23

Suggestions:
Have a button send the data to the clipboard.
Make it "bothways" making adding in faster.

![screenshot 2015-04-25 16 48 48](https://cloud.githubusercontent.com/assets/3985099/7333468/ec2536fc-eb70-11e4-8beb-557da0f8d81e.png)
