### PR TITLE
Fixed: Access to Yaw expo in Receiver Tab

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -625,6 +625,9 @@
     "receiverRcExpo": {
         "message": "RC Expo"
     },
+	"receiverRcYawExpo": {
+        "message": "RC Yaw Expo"
+    },
     "receiverChannelMap": {
         "message": "Channel Map"
     },

--- a/js/data_storage.js
+++ b/js/data_storage.js
@@ -75,7 +75,8 @@ var RC_tuning = {
     dynamic_THR_PID: 0,
     throttle_MID:    0,
     throttle_EXPO:   0,
-    dynamic_THR_breakpoint: 0
+    dynamic_THR_breakpoint: 0,
+	RC_YAW_EXPO:         0
 };
 
 var AUX_CONFIG = [];

--- a/js/msp.js
+++ b/js/msp.js
@@ -310,6 +310,9 @@ var MSP = {
                 if (semver.gte(CONFIG.apiVersion, "1.7.0")) {
                     RC_tuning.dynamic_THR_breakpoint = data.getUint16(offset++, 1);
                 }
+				if (semver.gte(CONFIG.apiVersion, "1.10.0")) {
+                    RC_tuning.RC_YAW_EXPO = parseFloat((data.getUint8(offset++) / 100).toFixed(2));
+                }
                 break;
             case MSP_codes.MSP_PID:
                 // PID data arrived, we need to scale it and save to appropriate bank / array
@@ -965,6 +968,9 @@ MSP.crunch = function (code) {
             if (semver.gte(CONFIG.apiVersion, "1.7.0")) {
                 buffer.push(lowByte(RC_tuning.dynamic_THR_breakpoint));
                 buffer.push(highByte(RC_tuning.dynamic_THR_breakpoint));
+            }
+			if (semver.gte(CONFIG.apiVersion, "1.10.0")) {
+                buffer.push(parseInt(RC_tuning.RC_YAW_EXPO * 100));
             }
             break;
         // Disabled, cleanflight does not use MSP_SET_BOX.

--- a/js/msp.js
+++ b/js/msp.js
@@ -310,8 +310,8 @@ var MSP = {
                 if (semver.gte(CONFIG.apiVersion, "1.7.0")) {
                     RC_tuning.dynamic_THR_breakpoint = data.getUint16(offset++, 1);
                 }
-				if (semver.gte(CONFIG.apiVersion, "1.10.0")) {
-                    RC_tuning.RC_YAW_EXPO = parseFloat((data.getUint8(offset++) / 100).toFixed(2));
+				        if (semver.gte(CONFIG.apiVersion, "1.10.0")) {
+                  RC_tuning.RC_YAW_EXPO = parseFloat((data.getUint8(offset++) / 100).toFixed(2));
                 }
                 break;
             case MSP_codes.MSP_PID:

--- a/js/msp.js
+++ b/js/msp.js
@@ -308,7 +308,8 @@ var MSP = {
                 RC_tuning.throttle_MID = parseFloat((data.getUint8(offset++) / 100).toFixed(2));
                 RC_tuning.throttle_EXPO = parseFloat((data.getUint8(offset++) / 100).toFixed(2));
                 if (semver.gte(CONFIG.apiVersion, "1.7.0")) {
-                    RC_tuning.dynamic_THR_breakpoint = data.getUint16(offset++, 1);
+                    RC_tuning.dynamic_THR_breakpoint = data.getUint16(offset, 1);
+                    offset += 2;  // point past 16 bit (2 bytes)
                 }
 				        if (semver.gte(CONFIG.apiVersion, "1.10.0")) {
                   RC_tuning.RC_YAW_EXPO = parseFloat((data.getUint8(offset++) / 100).toFixed(2));

--- a/tabs/receiver.css
+++ b/tabs/receiver.css
@@ -119,6 +119,13 @@
 .tab-receiver .tunings .throttle {
     margin-bottom: 10px;
 }
+.tab-receiver .tunings .rate {
+    margin-bottom: 10px;
+}
+.tab-receiver .tunings .yaw_rate {
+    margin-left:  127px;
+    margin-bottom: 10px;
+}
 .tab-receiver .tunings table, .tab-receiver .tunings table th, .tab-receiver .tunings table td {
     padding: 4px;
     border: 1px solid #8b8b8b;

--- a/tabs/receiver.html
+++ b/tabs/receiver.html
@@ -17,12 +17,10 @@
             <tr>
                 <th i18n="receiverRcRate"></th>
                 <th i18n="receiverRcExpo"></th>
-				<th i18n="receiverRcYawExpo"></th>
             </tr>
             <tr>
                 <td><input type="number" name="rate" step="0.01" min="0" max="2.5" /></td>
                 <td><input type="number" name="expo" step="0.01" min="0" max="1" /></td>
-				<td><input type="number" name="yaw_expo" step="0.01" min="0" max="1" /></td>
             </tr>
         </table>
         <div class="rssi_channel_wrapper">
@@ -44,6 +42,16 @@
                 </select>
             </div>
         </div>
+		<div class="yaw_rate">
+		<table class="yaw_rate">
+            <tr>
+				<th i18n="receiverRcYawExpo"></th>
+            </tr>
+            <tr>
+				<td><input type="number" name="yaw_expo" step="0.01" min="0" max="1" /></td>
+            </tr>
+        </table>
+		</div>
     </div>
     <div class="curves">
         <div class="throttle_curve">

--- a/tabs/receiver.html
+++ b/tabs/receiver.html
@@ -17,10 +17,12 @@
             <tr>
                 <th i18n="receiverRcRate"></th>
                 <th i18n="receiverRcExpo"></th>
+				<th i18n="receiverRcYawExpo"></th>
             </tr>
             <tr>
                 <td><input type="number" name="rate" step="0.01" min="0" max="2.5" /></td>
                 <td><input type="number" name="expo" step="0.01" min="0" max="1" /></td>
+				<td><input type="number" name="yaw_expo" step="0.01" min="0" max="1" /></td>
             </tr>
         </table>
         <div class="rssi_channel_wrapper">

--- a/tabs/receiver.html
+++ b/tabs/receiver.html
@@ -23,6 +23,14 @@
                 <td><input type="number" name="expo" step="0.01" min="0" max="1" /></td>
             </tr>
         </table>
+        <table class="yaw_rate">
+            <tr>
+              <th i18n="receiverRcYawExpo"></th>
+            </tr>
+            <tr>
+				      <td><input type="number" name="yaw_expo" step="0.01" min="0" max="1" /></td>
+            </tr>
+        </table>
         <div class="rssi_channel_wrapper">
             <div class="head" i18n="receiverRssiChannel"></div>
             <select name="rssi_channel">
@@ -42,16 +50,6 @@
                 </select>
             </div>
         </div>
-		<div class="yaw_rate">
-		<table class="yaw_rate">
-            <tr>
-				<th i18n="receiverRcYawExpo"></th>
-            </tr>
-            <tr>
-				<td><input type="number" name="yaw_expo" step="0.01" min="0" max="1" /></td>
-            </tr>
-        </table>
-		</div>
     </div>
     <div class="curves">
         <div class="throttle_curve">

--- a/tabs/receiver.js
+++ b/tabs/receiver.js
@@ -37,7 +37,12 @@ TABS.receiver.initialize = function (callback) {
 
         $('.tunings .rate input[name="rate"]').val(RC_tuning.RC_RATE.toFixed(2));
         $('.tunings .rate input[name="expo"]').val(RC_tuning.RC_EXPO.toFixed(2));
-
+		$('.tunings .rate input[name="yaw_expo"]').val(RC_tuning.RC_YAW_EXPO.toFixed(2));
+        
+		if (semver.lt(CONFIG.apiVersion, "1.10.0")) {
+            $('.tunings .rate input[name="yaw_expo"]').hide();
+        }
+		
         chrome.storage.local.get('rx_refresh_rate', function (result) {
             if (result.rx_refresh_rate) {
                 $('select[name="rx_refresh_rate"]').val(result.rx_refresh_rate).change();
@@ -268,6 +273,7 @@ TABS.receiver.initialize = function (callback) {
 
             RC_tuning.RC_RATE = parseFloat($('.tunings .rate input[name="rate"]').val());
             RC_tuning.RC_EXPO = parseFloat($('.tunings .rate input[name="expo"]').val());
+			RC_tuning.RC_YAW_EXPO = parseFloat($('.tunings .rate input[name="yaw_expo"]').val());
 
             // catch rc map
             var RC_MAP_Letters = ['A', 'E', 'R', 'T', '1', '2', '3', '4'];

--- a/tabs/receiver.js
+++ b/tabs/receiver.js
@@ -37,10 +37,10 @@ TABS.receiver.initialize = function (callback) {
 
         $('.tunings .rate input[name="rate"]').val(RC_tuning.RC_RATE.toFixed(2));
         $('.tunings .rate input[name="expo"]').val(RC_tuning.RC_EXPO.toFixed(2));
-		$('.tunings .rate input[name="yaw_expo"]').val(RC_tuning.RC_YAW_EXPO.toFixed(2));
+		$('.tunings .yaw_rate input[name="yaw_expo"]').val(RC_tuning.RC_YAW_EXPO.toFixed(2));
         
 		if (semver.lt(CONFIG.apiVersion, "1.10.0")) {
-            $('.tunings .rate input[name="yaw_expo"]').hide();
+            $('.tunings .yaw_rate input[name="yaw_expo"]').hide();
         }
 		
         chrome.storage.local.get('rx_refresh_rate', function (result) {
@@ -273,7 +273,7 @@ TABS.receiver.initialize = function (callback) {
 
             RC_tuning.RC_RATE = parseFloat($('.tunings .rate input[name="rate"]').val());
             RC_tuning.RC_EXPO = parseFloat($('.tunings .rate input[name="expo"]').val());
-			RC_tuning.RC_YAW_EXPO = parseFloat($('.tunings .rate input[name="yaw_expo"]').val());
+			RC_tuning.RC_YAW_EXPO = parseFloat($('.tunings .yaw_rate input[name="yaw_expo"]').val());
 
             // catch rc map
             var RC_MAP_Letters = ['A', 'E', 'R', 'T', '1', '2', '3', '4'];

--- a/tabs/receiver.js
+++ b/tabs/receiver.js
@@ -37,9 +37,9 @@ TABS.receiver.initialize = function (callback) {
 
         $('.tunings .rate input[name="rate"]').val(RC_tuning.RC_RATE.toFixed(2));
         $('.tunings .rate input[name="expo"]').val(RC_tuning.RC_EXPO.toFixed(2));
-		$('.tunings .yaw_rate input[name="yaw_expo"]').val(RC_tuning.RC_YAW_EXPO.toFixed(2));
+		    $('.tunings .yaw_rate input[name="yaw_expo"]').val(RC_tuning.RC_YAW_EXPO.toFixed(2));
         
-		if (semver.lt(CONFIG.apiVersion, "1.10.0")) {
+		    if (semver.lt(CONFIG.apiVersion, "1.10.0")) {
             $('.tunings .yaw_rate input[name="yaw_expo"]').hide();
         }
 		


### PR DESCRIPTION
Fixed. yaw expo is displayed correct and can be edited in receiver tab.
PR re-based on top of 0.63.2 d10023ec4b512395a07da9ac9f6d280f063a5fa6
Replaces #180 