### PR TITLE
Sensor tab: Fix freeze on tab open on Chome 46

### DIFF
--- a/tabs/sensors.js
+++ b/tabs/sensors.js
@@ -14,7 +14,8 @@ TABS.sensors.initialize = function (callback) {
             SENSOR_DATA.accelerometer[i] = 0;
             SENSOR_DATA.gyroscope[i] = 0;
             SENSOR_DATA.magnetometer[i] = 0;
-            SENSOR_DATA.sonar[i] = 0;
+            SENSOR_DATA.sonar = 0;
+            SENSOR_DATA.altitude = 0;
             SENSOR_DATA.debug[i] = 0;
         }
     }


### PR DESCRIPTION
This fixes the bug (#240) which causes the Sensors tab to freeze upon initialisation on Chrome 46.