### PR TITLE
Pid Tab rework

### DIFF
--- a/tabs/pid_tuning.css
+++ b/tabs/pid_tuning.css
@@ -19,6 +19,14 @@
 .tab-pid_tuning table tr td:first-child {
     text-align: center;
 }
+.tab-pid_tuning table tr.LEVEL,
+.tab-pid_tuning table tr.ALT,
+.tab-pid_tuning table tr.MAG,
+.tab-pid_tuning table tr.Pos,
+.tab-pid_tuning table tr.PosR,
+.tab-pid_tuning table tr.NavR {
+  display:none;
+}
 .tab-pid_tuning table td {
     padding: 1px;
 }

--- a/tabs/pid_tuning.css
+++ b/tabs/pid_tuning.css
@@ -22,6 +22,7 @@
 .tab-pid_tuning table tr.LEVEL,
 .tab-pid_tuning table tr.ALT,
 .tab-pid_tuning table tr.MAG,
+.tab-pid_tuning table tr.Vario,
 .tab-pid_tuning table tr.Pos,
 .tab-pid_tuning table tr.PosR,
 .tab-pid_tuning table tr.NavR {

--- a/tabs/pid_tuning.html
+++ b/tabs/pid_tuning.html
@@ -14,6 +14,7 @@
     <div class="clear-both"></div>
     <form name="pid-tuning" id="pid-tuning">
         <table class="pid_tuning">
+            <tr class="title"><td colspan="4">Basic/Acro</td></tr>
             <tr>
                 <th class="name" i18n="pidTuningName"></th>
                 <th class="proportional" i18n="pidTuningProportional"></th>
@@ -38,28 +39,33 @@
                 <td><input type="number" name="i" step="0.001" min="0" max="0.255"/></td>
                 <td><input type="number" name="d" step="1" min="0" max="255"/></td>
             </tr>
+            <tr class="title"><td colspan="4">Accelerometer/Level</td></tr>
             <tr class="LEVEL"><!-- 7 -->
                 <td></td>
                 <td><input type="number" name="p" step="0.1" min="0" max="25.5"/></td>
                 <td><input type="number" name="i" step="0.001" min="0" max="0.255"/></td>
                 <td><input type="number" name="d" step="1" min="0" max="255"/></td>
             </tr>
+            <tr class="title"><td colspan="4">Barometer/Altitude</td></tr>
             <tr class="ALT"><!-- 3 -->
                 <td></td>
                 <td><input type="number" name="p" step="0.1" min="0" max="25.5"/></td>
                 <td><input type="number" name="i" step="0.001" min="0" max="0.255"/></td>
                 <td><input type="number" name="d" step="1" min="0" max="255"/></td>
             </tr>
+            <tr class="title"><td colspan="4">Magnometer/Heading</td></tr>
             <tr class="MAG"><!-- 8 -->
                 <td></td>
                 <td><input type="number" name="p" step="0.1" min="0" max="25.5"/></td>
             </tr>
+            <tr class="title"><td colspan="4">Sonar</td></tr>
             <tr class="Vario"><!-- 9 -->
                 <td></td>
                 <td><input type="number" name="p" step="0.1" min="0" max="25.5"/></td>
                 <td><input type="number" name="i" step="0.001" min="0" max="0.255"/></td>
                 <td><input type="number" name="d" step="1" min="0" max="255"/></td>
             </tr>
+            <tr class="title"><td colspan="4">GPS Navigation</td></tr>
             <tr class="Pos"><!-- 4 -->
                 <td></td>
                 <td><input type="number" name="p" step="0.01" min="0" max="2.55"/></td>

--- a/tabs/pid_tuning.html
+++ b/tabs/pid_tuning.html
@@ -38,11 +38,21 @@
                 <td><input type="number" name="i" step="0.001" min="0" max="0.255"/></td>
                 <td><input type="number" name="d" step="1" min="0" max="255"/></td>
             </tr>
+            <tr class="LEVEL"><!-- 7 -->
+                <td></td>
+                <td><input type="number" name="p" step="0.1" min="0" max="25.5"/></td>
+                <td><input type="number" name="i" step="0.001" min="0" max="0.255"/></td>
+                <td><input type="number" name="d" step="1" min="0" max="255"/></td>
+            </tr>
             <tr class="ALT"><!-- 3 -->
                 <td></td>
                 <td><input type="number" name="p" step="0.1" min="0" max="25.5"/></td>
                 <td><input type="number" name="i" step="0.001" min="0" max="0.255"/></td>
                 <td><input type="number" name="d" step="1" min="0" max="255"/></td>
+            </tr>
+            <tr class="MAG"><!-- 8 -->
+                <td></td>
+                <td><input type="number" name="p" step="0.1" min="0" max="25.5"/></td>
             </tr>
             <tr class="Vario"><!-- 9 -->
                 <td></td>
@@ -66,16 +76,6 @@
                 <td><input type="number" name="p" step="0.1" min="0" max="25.5"/></td>
                 <td><input type="number" name="i" step="0.01" min="0" max="2.55"/></td>
                 <td><input type="number" name="d" step="0.001" min="0" max="0.255"/></td>
-            </tr>
-            <tr class="LEVEL"><!-- 7 -->
-                <td></td>
-                <td><input type="number" name="p" step="0.1" min="0" max="25.5"/></td>
-                <td><input type="number" name="i" step="0.001" min="0" max="0.255"/></td>
-                <td><input type="number" name="d" step="1" min="0" max="255"/></td>
-            </tr>
-            <tr class="MAG"><!-- 8 -->
-                <td></td>
-                <td><input type="number" name="p" step="0.1" min="0" max="25.5"/></td>
             </tr>
         </table>
         <table class="rate-tpa">

--- a/tabs/pid_tuning.js
+++ b/tabs/pid_tuning.js
@@ -49,7 +49,7 @@ TABS.pid_tuning.initialize = function (callback) {
           $('table.pid_tuning tr.NavR').show();
         }
         if ($('#sensor-status .sonar').hasClass('on')) {
-          $('table.pid_tuning tr.LEVEL').show();
+          $('table.pid_tuning tr.Vario').show();
         }
     }
 

--- a/tabs/pid_tuning.js
+++ b/tabs/pid_tuning.js
@@ -34,6 +34,23 @@ TABS.pid_tuning.initialize = function (callback) {
 
     function load_html() {
         $('#content').load("./tabs/pid_tuning.html", process_html);
+        if ($('#sensor-status .accel').hasClass('on')) {
+          $('table.pid_tuning tr.LEVEL').show();
+        }
+        if ($('#sensor-status .baro').hasClass('on')) {
+          $('table.pid_tuning tr.ALT').show();
+        }
+        if ($('#sensor-status .mag').hasClass('on')) {
+          $('table.pid_tuning tr.MAG').show();
+        }
+        if ($('#sensor-status .gps').hasClass('on')) {
+          $('table.pid_tuning tr.Pos').show();
+          $('table.pid_tuning tr.PosR').show();
+          $('table.pid_tuning tr.NavR').show();
+        }
+        if ($('#sensor-status .sonar').hasClass('on')) {
+          $('table.pid_tuning tr.LEVEL').show();
+        }
     }
 
     // requesting MSP_STATUS manually because it contains CONFIG.profile
@@ -274,7 +291,7 @@ TABS.pid_tuning.initialize = function (callback) {
 
             pidController_e.prop('disabled', true);
         }
-        
+
         if (semver.lt(CONFIG.apiVersion, "1.7.0")) {
             $('.rate-tpa .tpa-breakpoint').hide();
             $('.rate-tpa .roll').hide();


### PR DESCRIPTION
Reworked the PID page so only the PIDs for attached devices show up.  Also refactored the code that handled the naming of the rows for PID values to not be dependent on order.  Now matches the row class to the PID_names value.