### PR TITLE
MSP_SET_RXFAIL_CONFIG changed to allow more future RX channels

### DIFF
--- a/js/backup_restore.js
+++ b/js/backup_restore.js
@@ -676,7 +676,6 @@ function configuration_restore(callback) {
                     if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
                         uniqueData.push(MSP_codes.MSP_SET_RX_CONFIG);
                         uniqueData.push(MSP_codes.MSP_SET_FAILSAFE_CONFIG);
-                        uniqueData.push(MSP_codes.MSP_SET_RXFAIL_CONFIG);
                     }
                 }
                 
@@ -701,7 +700,7 @@ function configuration_restore(callback) {
                             send_unique_data_item();
                         });
                     } else {
-                        MSP.send_message(MSP_codes.MSP_EEPROM_WRITE, false, false, send_led_strip_config);
+                        send_led_strip_config();
                     }
                 }
 
@@ -714,9 +713,21 @@ function configuration_restore(callback) {
             }
 
             function send_led_strip_config() {
-                MSP.sendLedStripConfig(reboot);
+                MSP.sendLedStripConfig(send_rxfail_config);
             }
             
+            function send_rxfail_config() {
+                if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+                    MSP.sendRxFailConfig(save_to_eeprom);
+                } else {
+                    save_to_eeprom();
+                }
+            }
+
+            function save_to_eeprom() {
+                MSP.send_message(MSP_codes.MSP_EEPROM_WRITE, false, false, reboot);
+            }
+
             function reboot() {
                 GUI.log(chrome.i18n.getMessage('eeprom_saved_ok'));
 

--- a/js/msp.js
+++ b/js/msp.js
@@ -800,12 +800,14 @@ var MSP = {
                 offset++;
                 FAILSAFE_CONFIG.failsafe_throttle = data.getUint16(offset, 1);
                 offset += 2;
-                FAILSAFE_CONFIG.failsafe_kill_switch = data.getUint8(offset, 1);
-                offset++;
-                FAILSAFE_CONFIG.failsafe_throttle_low_delay = data.getUint16(offset, 1);
-                offset += 2;
-                FAILSAFE_CONFIG.failsafe_procedure = data.getUint8(offset, 1);
-                offset++;
+                if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+                    FAILSAFE_CONFIG.failsafe_kill_switch = data.getUint8(offset, 1);
+                    offset++;
+                    FAILSAFE_CONFIG.failsafe_throttle_low_delay = data.getUint16(offset, 1);
+                    offset += 2;
+                    FAILSAFE_CONFIG.failsafe_procedure = data.getUint8(offset, 1);
+                    offset++;
+                }
                 break;
 
             case MSP_codes.MSP_RXFAIL_CONFIG:
@@ -1178,17 +1180,11 @@ MSP.crunch = function (code) {
             buffer.push(FAILSAFE_CONFIG.failsafe_off_delay);
             buffer.push(lowByte(FAILSAFE_CONFIG.failsafe_throttle));
             buffer.push(highByte(FAILSAFE_CONFIG.failsafe_throttle));
-            buffer.push(FAILSAFE_CONFIG.failsafe_kill_switch);
-            buffer.push(lowByte(FAILSAFE_CONFIG.failsafe_throttle_low_delay));
-            buffer.push(highByte(FAILSAFE_CONFIG.failsafe_throttle_low_delay));
-            buffer.push(FAILSAFE_CONFIG.failsafe_procedure);
-            break;
-
-        case MSP_codes.MSP_SET_RXFAIL_CONFIG:
-            for (var i = 0; i < RXFAIL_CONFIG.length; i++) {
-                buffer.push(RXFAIL_CONFIG[i].mode);
-                buffer.push(lowByte(RXFAIL_CONFIG[i].value));
-                buffer.push(highByte(RXFAIL_CONFIG[i].value));
+            if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+                buffer.push(FAILSAFE_CONFIG.failsafe_kill_switch);
+                buffer.push(lowByte(FAILSAFE_CONFIG.failsafe_throttle_low_delay));
+                buffer.push(highByte(FAILSAFE_CONFIG.failsafe_throttle_low_delay));
+                buffer.push(FAILSAFE_CONFIG.failsafe_procedure);
             }
             break;
 
@@ -1312,10 +1308,10 @@ MSP.sendServoConfigurations = function(onCompleteCallback) {
 
     if (SERVO_CONFIG.length == 0) {
         onCompleteCallback();
+    } else {
+        nextFunction();
     }
-    
-    nextFunction();
-    
+
     function send_next_servo_configuration() {
         
         var buffer = [];
@@ -1402,11 +1398,10 @@ MSP.sendModeRanges = function(onCompleteCallback) {
 
     if (MODE_RANGES.length == 0) {
         onCompleteCallback();
+    } else {
+        send_next_mode_range();
     }
-    
-    send_next_mode_range();
 
-    
     function send_next_mode_range() {
         
         var modeRange = MODE_RANGES[modeRangeIndex];
@@ -1435,11 +1430,10 @@ MSP.sendAdjustmentRanges = function(onCompleteCallback) {
 
     if (ADJUSTMENT_RANGES.length == 0) {
         onCompleteCallback();
+    } else {
+        send_next_adjustment_range();
     }
-    
-    send_next_adjustment_range();
 
-    
     function send_next_adjustment_range() {
         
         var adjustmentRange = ADJUSTMENT_RANGES[adjustmentRangeIndex];
@@ -1471,9 +1465,9 @@ MSP.sendLedStripConfig = function(onCompleteCallback) {
 
     if (LED_STRIP.length == 0) {
         onCompleteCallback();
+    } else {
+        send_next_led_strip_config();
     }
-    
-    send_next_led_strip_config();
 
     function send_next_led_strip_config() {
         
@@ -1540,3 +1534,34 @@ MSP.serialPortFunctionsToMask = function(functions) {
     }
     return mask;
 }
+
+MSP.sendRxFailConfig = function(onCompleteCallback) {
+    var nextFunction = send_next_rxfail_config;
+
+    var rxFailIndex = 0;
+
+    if (RXFAIL_CONFIG.length == 0) {
+        onCompleteCallback();
+    } else {
+        send_next_rxfail_config();
+    }
+
+    function send_next_rxfail_config() {
+
+        var rxFail = RXFAIL_CONFIG[rxFailIndex];
+
+        var buffer = [];
+        buffer.push(rxFailIndex);
+        buffer.push(rxFail.mode);
+        buffer.push(lowByte(rxFail.value));
+        buffer.push(highByte(rxFail.value));
+
+        // prepare for next iteration
+        rxFailIndex++;
+        if (rxFailIndex == RXFAIL_CONFIG.length) {
+            nextFunction = onCompleteCallback;
+
+        }
+        MSP.send_message(MSP_codes.MSP_SET_RXFAIL_CONFIG, buffer, false, nextFunction);
+    }
+};

--- a/tabs/failsafe.js
+++ b/tabs/failsafe.js
@@ -317,7 +317,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
             }
 
             function save_rxfail_config() {
-                MSP.send_message(MSP_codes.MSP_SET_RXFAIL_CONFIG, MSP.crunch(MSP_codes.MSP_SET_RXFAIL_CONFIG), false, save_bf_config);
+                MSP.sendRxFailConfig(save_bf_config);
             }
 
             function save_bf_config() {


### PR DESCRIPTION
@hydra This is the change you mentioned on IRC the other day:
~~~
[22:04] <hydra_> ProDrone: if we ever support more than 18 channels we will have a problem with this:
[22:04] <hydra_> #define MSP_SET_RXFAIL_CONFIG           78 //in message          Sets RXFAIL settings
[22:04] <hydra_> #define INBUF_SIZE 64
[22:05] <hydra_> 18 * 3 = 54
[22:05] <hydra_> just so you're aware.
[22:05] <hydra_> a different approach is taken for things like the LED_STRIP configuration, etc.
[22:06] <hydra_> an index is supplied with the data. and one message is set for each index that needs to be sent.
[22:07] <hydra_> in an alternative world the FC would then be sent up to 18 rxfail messages, each with an index and 3 extra bytes payload
[22:07] <hydra_> no worries.  might be worth doing this now before the next configurator and CF release
[22:07] <hydra_> see if you think it's worth it.
[22:08] <hydra_> it simplifies the FC code but complicates the configurator code, but a pattern is already set in the configurator so you can follow it.
[22:09] <hydra_> it's not complicated to do either.
[22:09] <hydra_> I'll merge the configurator changes now, since they will work with the current code.
[22:09] <hydra_> then you can give me a PR for both if you have time.
~~~

__NOTES:__
- This goes together with cleanflight pull request: https://github.com/cleanflight/cleanflight/pull/1590
- Includes a bug-fix for saving the LED strip config.
- Includes some other bug-fixes to prevent processing of zero length data.