### PR TITLE
CLI: Fix error after exit command

### DIFF
--- a/tabs/cli.js
+++ b/tabs/cli.js
@@ -174,7 +174,7 @@ TABS.cli.read = function (readInfo) {
                     GUI.timeout_add('waiting_for_bootup', function waiting_for_bootup() {
                         MSP.send_message(MSP_codes.MSP_IDENT, false, false, function () {
                             GUI.log(chrome.i18n.getMessage('deviceReady'));
-                            if (!this.tab_switch_in_progress) {
+                            if (!GUI.tab_switch_in_progress) {
                                 $('#tabs ul.mode-connected .tab_setup a').click();
                             }
                         });


### PR DESCRIPTION
This fixes the undefined reference error and allows the configurator to automatically switch to the main tab after exiting the CLI.