### PR TITLE
Add vibrations RMS to Motors tab

### DIFF
--- a/tabs/motors.css
+++ b/tabs/motors.css
@@ -30,7 +30,7 @@
     width: 160px;
     /* border: 1px solid silver; */
     height: 100%;
-    height: 160px;
+    height: 180px;
     margin: 0px;
     background-color: #ECECEC;
     border-top-right-radius: 3px;
@@ -97,6 +97,18 @@
 
 .tab-motors .plot_control .z {
     background-color: #CB4B4B;
+    padding: 3px;
+    color: #fff;
+    height: 12px;
+    float: right;
+    border-radius: 3px;
+    line-height: 12px;
+    margin-bottom: 2px;
+    text-align: right;
+}
+
+.tab-motors .plot_control .rms {
+    background-color: #00D800;
     padding: 3px;
     color: #fff;
     height: 12px;

--- a/tabs/motors.html
+++ b/tabs/motors.html
@@ -54,6 +54,8 @@
                         <dd class="y">0</dd>
                         <dt>Z:</dt>
                         <dd class="z">0</dd>
+                        <dt>RMS:</dt>
+                        <dd class="rms">0</dd>
                     </dl>
                 </div>
             </div>

--- a/tabs/motors.js
+++ b/tabs/motors.js
@@ -264,7 +264,7 @@ TABS.motors.initialize = function (callback) {
                 ];
 
                 updateGraphHelperSize(accelHelpers);
-                samples_accel_i = addSampleToData(accel_data, samples_accel_i, accel_with_offset,rms);
+                samples_accel_i = addSampleToData(accel_data, samples_accel_i, accel_with_offset);
                 drawGraph(accelHelpers, accel_data, samples_accel_i);
 
                 // Compute RMS of acceleration in displayed period of time

--- a/tabs/motors.js
+++ b/tabs/motors.js
@@ -271,18 +271,9 @@ TABS.motors.initialize = function (callback) {
                 // This is particularly useful for motor balancing as it 
                 // eliminates the need for external tools
                 var sum = 0.0;
-                for (var k = 0; k < accel_data[0].length; k++)
-                {
-                    sum += accel_data[0][k][1]*accel_data[0][k][1];
-                }
-                for (var k = 0; k < accel_data[1].length; k++)
-                {
-                    sum += accel_data[1][k][1]*accel_data[1][k][1];
-                }
-                for (var k = 0; k < accel_data[2].length; k++)
-                {
-                    sum += accel_data[2][k][1]*accel_data[2][k][1];
-                }
+                for (var j = 0; j < accel_data.length; j++)
+                    for (var k = 0; k < accel_data[0].length; k++)
+                       sum += accel_data[j][k][1]*accel_data[j][k][1];
                 var rms = Math.sqrt(sum/(accel_data[0].length+accel_data[1].length+accel_data[2].length));
 
                 raw_data_text_ements.x[0].text(accel_with_offset[0].toFixed(2) + ' (' + accel_max_read[0].toFixed(2) + ')');

--- a/tabs/motors.js
+++ b/tabs/motors.js
@@ -66,7 +66,6 @@ TABS.motors.initialize = function (callback) {
         }
         return data;
     }
-
     function addSampleToData(data, sampleNumber, sensorData) {
         for (var i = 0; i < data.length; i++) {
             var dataPoint = sensorData[i];
@@ -78,6 +77,7 @@ TABS.motors.initialize = function (callback) {
                 data[i].max = dataPoint;
             }
         }
+
         while (data[0].length > 300) {
             for (i = 0; i < data.length; i++) {
                 data[i].shift();
@@ -201,17 +201,20 @@ TABS.motors.initialize = function (callback) {
         var raw_data_text_ements = {
             x: [],
             y: [],
-            z: []
+            z: [],
+            rms: []
         };
 
-        $('.plot_control .x, .plot_control .y, .plot_control .z').each(function () {
+        $('.plot_control .x, .plot_control .y, .plot_control .z, .plot_control .rms').each(function () {
             var el = $(this);
             if (el.hasClass('x')) {
                 raw_data_text_ements.x.push(el);
             } else if (el.hasClass('y')) {
                 raw_data_text_ements.y.push(el);
-            } else {
+            } else if (el.hasClass('z')) {
                 raw_data_text_ements.z.push(el);
+            } else if (el.hasClass('rms')) {
+                raw_data_text_ements.rms.push(el);
             }
         });
 
@@ -261,12 +264,31 @@ TABS.motors.initialize = function (callback) {
                 ];
 
                 updateGraphHelperSize(accelHelpers);
-                samples_accel_i = addSampleToData(accel_data, samples_accel_i, accel_with_offset);
+                samples_accel_i = addSampleToData(accel_data, samples_accel_i, accel_with_offset,rms);
                 drawGraph(accelHelpers, accel_data, samples_accel_i);
+
+                // Compute RMS of acceleration in displayed period of time
+                // This is particularly useful for motor balancing as it 
+                // eliminates the need for external tools
+                var sum = 0.0;
+                for (var k = 0; k < accel_data[0].length; k++)
+                {
+                    sum += accel_data[0][k][1]*accel_data[0][k][1];
+                }
+                for (var k = 0; k < accel_data[1].length; k++)
+                {
+                    sum += accel_data[1][k][1]*accel_data[1][k][1];
+                }
+                for (var k = 0; k < accel_data[2].length; k++)
+                {
+                    sum += accel_data[2][k][1]*accel_data[2][k][1];
+                }
+                var rms = Math.sqrt(sum/(accel_data[0].length+accel_data[1].length+accel_data[2].length));
 
                 raw_data_text_ements.x[0].text(accel_with_offset[0].toFixed(2) + ' (' + accel_max_read[0].toFixed(2) + ')');
                 raw_data_text_ements.y[0].text(accel_with_offset[1].toFixed(2) + ' (' + accel_max_read[1].toFixed(2) + ')');
                 raw_data_text_ements.z[0].text(accel_with_offset[2].toFixed(2) + ' (' + accel_max_read[2].toFixed(2) + ')');
+                raw_data_text_ements.rms[0].text(rms.toFixed(4));
 
                 for (var i = 0; i < 3; i++) {
                     if (Math.abs(accel_with_offset[i]) > Math.abs(accel_max_read[i])) accel_max_read[i] = accel_with_offset[i];

--- a/tabs/motors.js
+++ b/tabs/motors.js
@@ -66,6 +66,7 @@ TABS.motors.initialize = function (callback) {
         }
         return data;
     }
+
     function addSampleToData(data, sampleNumber, sensorData) {
         for (var i = 0; i < data.length; i++) {
             var dataPoint = sensorData[i];
@@ -77,7 +78,6 @@ TABS.motors.initialize = function (callback) {
                 data[i].max = dataPoint;
             }
         }
-
         while (data[0].length > 300) {
             for (i = 0; i < data.length; i++) {
                 data[i].shift();

--- a/tabs/motors.js
+++ b/tabs/motors.js
@@ -272,7 +272,7 @@ TABS.motors.initialize = function (callback) {
                 // eliminates the need for external tools
                 var sum = 0.0;
                 for (var j = 0; j < accel_data.length; j++)
-                    for (var k = 0; k < accel_data[0].length; k++)
+                    for (var k = 0; k < accel_data[j].length; k++)
                        sum += accel_data[j][k][1]*accel_data[j][k][1];
                 var rms = Math.sqrt(sum/(accel_data[0].length+accel_data[1].length+accel_data[2].length));
 


### PR DESCRIPTION
Many people balance their props but only few balance also their motors. However, I found in my quadcopter that balancing the motors themselves increased the stability quite a bit.
If you look around (e.g. on youtube) you will find people gluing their smartphones to their copters to measure the vibrations. The smartphone application gives you the RMS of the vibrations, so you directly have a number for the *amount of vibrations* in your system. So if you do certain thing to balance the motor you can see if you are doing the right thing.

My pull request implements the computation and display of the vibration RMS in the Motors tab of the Cleanflight Configurator.
Note: The time scale of the RMS computation can be set by changing the refresh rate of the graph.

**This is an important feature as it eliminates the need for any external tool that has (somehow) to be fixed to the quadcopter for the motor balancing procedure.**
I always felt that this feature is missing in the Configurator and a natural extension of the Motors tab. I create this pull request as I think that many others will also benefit from this feature.

Examples:
Fairly quiet environment, no motor running (RMS is very small, about 0.003).
![screenshot-1](https://cloud.githubusercontent.com/assets/16748619/12380259/0124b4bc-bd6f-11e5-94d3-0bee831664b1.png)

Balanced motor at 1200 (RMS reading goes up to 0.01)
![screenshot-3](https://cloud.githubusercontent.com/assets/16748619/12380284/7042b13c-bd6f-11e5-87d7-5b6895164fa5.png)

An unbalanced motor running at the same speed (RMS gets large, 0.08)
![screenshot-4](https://cloud.githubusercontent.com/assets/16748619/12380295/d7a16d32-bd6f-11e5-807b-a9b70247c35c.png)

After a single balancing trial of this motor, the RMS decreases, so we are doing it right. However, if one only looks at the graph it is harder to see than when having a single number to compare to.
![screenshot-6](https://cloud.githubusercontent.com/assets/16748619/12385805/1963751c-bdc0-11e5-8968-0b6565ff7276.png)

Note: It might be necessary to click of **[Reset]** before doing the measurements.