### PR TITLE
ISO date for backup filename, localized timestamps in logs

### DIFF
--- a/js/backup_restore.js
+++ b/js/backup_restore.js
@@ -161,8 +161,11 @@ function configuration_backup(callback) {
         }];
 
         // generate timestamp for the backup file
-        var d = new Date(),
-            now = (d.getMonth() + 1) + '.' + d.getDate() + '.' + d.getFullYear() + '.' + d.getHours() + '.' + d.getMinutes();
+        var d = new Date();
+        var now = d.toISOString().substring(0, 10) + 'T' +
+                (d.getHours() < 10 ? '0' : '') + d.getHours() +
+                '-' +
+                (d.getMinutes() < 10 ? '0' : '') + d.getMinutes();
 
         // create or load the file
         chrome.fileSystem.chooseEntry({type: 'saveFile', suggestedName: 'cleanflight_backup_' + now, accepts: accepts}, function (fileEntry) {

--- a/js/gui.js
+++ b/js/gui.js
@@ -208,19 +208,11 @@ GUI_control.prototype.timeout_kill_all = function () {
 GUI_control.prototype.log = function (message) {
     var command_log = $('div#log');
     var d = new Date();
-    var year = d.getFullYear();
-    var month = ((d.getMonth() < 9) ? '0' + (d.getMonth() + 1) : (d.getMonth() + 1));
-    var date =  ((d.getDate() < 10) ? '0' + d.getDate() : d.getDate());
-    var time = ((d.getHours() < 10) ? '0' + d.getHours(): d.getHours())
-         + ':' + ((d.getMinutes() < 10) ? '0' + d.getMinutes(): d.getMinutes())
-         + ':' + ((d.getSeconds() < 10) ? '0' + d.getSeconds(): d.getSeconds());
+    var date = d.toISOString().substring(0, 10);
+    var time = d.toLocaleTimeString();
 
-    var formattedDate = "{0}-{1}-{2} {3}".format(
-                                year,
-                                month,
-                                date,
-                                ' @ ' + time
-                            );
+    var formattedDate = [date, time].join(' @ ');
+
     $('div.wrapper', command_log).append('<p>' + formattedDate + ' -- ' + message + '</p>');
     command_log.scrollTop($('div.wrapper', command_log).height());
 };


### PR DESCRIPTION
* In order to sort backup files (by backup created time, not file created/modified date) it's compulsory to use ISO date formatting (`YYYY-MM-DD`). The new filename pattern with these changes will be: `cleanflight_backup_YYYY-MM-DDTHH-MM` (e.g. `cleanflight_backup_2016-03-06T17-52`).
* Further, this PR simplifies the timestamp generation in the log section and gives the user a localized time format (e.g. '5:52:24 PM' for English users, '17:52:24' for me, etc.)