### PR TITLE
Board type detection before flashing

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1378,6 +1378,12 @@
     "firmwareFlasherShowDevelopmentReleasesDescription":{
         "message": "Show Release-Candidates and Development Releases."
     },
+    "firmwareFlasherDetectBoardType":{
+        "message": "Auto-Detect board type"
+    },
+    "firmwareFlasherDetectBoardTypeDescription":{
+        "message": "Attempt to automatically detect which kind of board is plugged in."
+    },
     "firmwareFlasherOptionLabelSelectFirmware": {
         "message": "Choose a Firmware / Board"
     },

--- a/js/boards.js
+++ b/js/boards.js
@@ -4,57 +4,76 @@ var BOARD_DEFINITIONS = [
     {
         name: "CC3D",
         identifier: "CC3D",
+        filename: "CC3D",
         vcp: true
     }, {
         name: "ChebuzzF3",
         identifier: "CHF3",
+        filename: false,
         vcp: false
     }, {
         name: "CJMCU",
         identifier: "CJM1",
+        filename: "CJMCU",
         vcp: false
     }, {
         name: "EUSTM32F103RB",
         identifier: "EUF1",
+        filename: false,
         vcp: false
     }, {
         name: "Naze/Flip32+",
         identifier: "AFNA",
+        filename: "NAZE",
         vcp: false
     }, {
         name: "Naze32Pro",
         identifier: "AFF3",
+        filename: "NAZE",
         vcp: false
     }, {
         name: "Olimexino",
-        identifier: "OLI1"
+        identifier: "OLI1",
+        filename: false
     }, {
         name: "Port103R",
         identifier: "103R",
+        filename: false,
+        vcp: false
+    }, {
+        name: "Seiously DODO",
+        identifier: "RMDO",
+        filename: "RMDO",
         vcp: false
     }, {
         name: "Sparky",
         identifier: "SPKY",
+        filename: "SPARKY",
         vcp: true
     }, {
         name: "STM32F3Discovery",
         identifier: "SDF3",
+        filename: false,
         vcp: true
     }, {
         name: "Colibri Race",
         identifier: "CLBR",
+        filename: "COLIBRI_RACE",
         vcp: true
     }, {
         name: "SP Racing F3",
         identifier: "SRF3",
+        filename: "SPRACINGF3",
         vcp: false
     }, {
         name: "SP Racing F3 Mini",
         identifier: "SRFM",
+        filename: "SPRACINGF3MINI",
         vcp: true
     }, {
         name: "MotoLab",
         identifier: "MOTO",
+        filename: "MOTOLAB",
         vcp: true
     }
 ];
@@ -62,6 +81,7 @@ var BOARD_DEFINITIONS = [
 var DEFAULT_BOARD_DEFINITION = {
     name: "Unknown",
     identifier: "????",
+    filename: false,
     vcp: false
 };
 

--- a/tabs/firmware_flasher.html
+++ b/tabs/firmware_flasher.html
@@ -3,7 +3,7 @@
         <div class="options gui_box">
             <div class="spacer">
                 <table class="cf_table" style="margin-top: 10px;">
-                    <tr>
+                    <tr class="noboarder">
                         <td><select name="release">
                                 <option value="0">Loading ...</option>
                         </select></td>
@@ -14,6 +14,12 @@
                                 i18n="firmwareFlasherNoReboot"></span>
                         </label></td>
                         <td><span class="description" i18n="firmwareFlasherNoRebootDescription"></span></td>
+                    </tr>
+                    <tr class="option detect_board_type_wrapper">
+                        <td><label> <input class="detect_board_type toggle" type="checkbox" /> <span
+                                i18n="firmwareFlasherDetectBoardType"></span>
+                        </label></td>
+                        <td><span class="description" i18n="firmwareFlasherDetectBoardTypeDescription"></span></td>
                     </tr>
                     <tr class="option flash_on_connect_wrapper">
                         <td><label> <input class="flash_on_connect toggle" type="checkbox" /> <span
@@ -50,6 +56,7 @@
                         </label></td>
                         <td><span class="description" i18n="firmwareFlasherShowDevelopmentReleasesDescription"></span></td>
                     </tr>
+
                 </table>
             </div>
         </div>


### PR DESCRIPTION
Okay so this is my first stab at https://github.com/cleanflight/cleanflight-configurator/issues/357 

I'm too stupid (= suck at JavaScript too much) to figure out how to make some kind of proper message telling the user he is using the wrong firmware.... so I just put it in the log... which is crappy. Something more visible should happen.

Lemme know what you think I should do about this....

