### PR TITLE
Mag calibration button fix in the setup tab

### DIFF
--- a/main.css
+++ b/main.css
@@ -1252,6 +1252,12 @@ dialog {
     text-decoration:none;
 }
 
+.default_btn a.disabled {
+    background-color: #fff;
+    border: 1px solid #ccc;
+    color: #ccc;
+}
+
 .default_btn a:hover {
     background-color: #6ac435;
     color: #fff;

--- a/tabs/setup.js
+++ b/tabs/setup.js
@@ -58,6 +58,8 @@ TABS.setup.initialize = function (callback) {
         // check if we have magnetometer
         if (!bit_check(CONFIG.activeSensors, 2)) {
             $('a.calibrateMag').addClass('disabled');
+            $('default_btn').addClass('disabled');
+
         }
 
         self.initializeInstruments();


### PR DESCRIPTION
<img width="366" alt="bildschirmfoto 2016-06-12 um 17 46 10" src="https://cloud.githubusercontent.com/assets/11768024/15992128/e0ffeede-30c5-11e6-9f05-010f56d73dce.png">

If no mag sensor is present the button is disabled but it was styled like all other active buttons.
This PR adds a new deactivated style to that button