### PR TITLE
update MSP_LED_STRIP_MODECOLOR

### DIFF
--- a/js/msp.js
+++ b/js/msp.js
@@ -43,8 +43,8 @@ var MSP_codes = {
     MSP_TRANSPONDER_CONFIG:      82,
     MSP_SET_TRANSPONDER_CONFIG:  83,
 
-    MSP_LED_STRIP_MODECOLOR:     86,
-    MSP_SET_LED_STRIP_MODECOLOR: 87,
+    MSP_LED_STRIP_MODECOLOR:     127,
+    MSP_SET_LED_STRIP_MODECOLOR: 221,
 
     // Multiwii MSP commands
     MSP_IDENT:              100,

--- a/tabs/led_strip.js
+++ b/tabs/led_strip.js
@@ -36,7 +36,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
     }
 
     function load_led_mode_colors() {
-        if (semver.gt(CONFIG.apiVersion, "1.19.0"))
+        if (semver.gte(CONFIG.apiVersion, "1.21.0"))
             MSP.send_message(MSP_codes.MSP_LED_STRIP_MODECOLOR, false, false, load_html);
         else
             load_html();


### PR DESCRIPTION
update MSP_LED_STRIP_MODE_COLOR id's
LED strip: disable setting of mode color in previous MSP versions
Linked to https://github.com/cleanflight/cleanflight/pull/2327