### PR TITLE
Add iBus telemetry option in ports tab

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -708,6 +708,9 @@
     "portsFunction_TELEMETRY_SMARTPORT": {
         "message": "SmartPort"
     },
+    "portsFunction_TELEMETRY_IBUS": {
+        "message": "IBus"
+    },
     "portsFunction_RX_SERIAL": {
         "message": "Serial RX"
     },

--- a/js/msp.js
+++ b/js/msp.js
@@ -185,6 +185,8 @@ var MSP = {
             'RX_SERIAL': 6,
             'BLACKBOX': 7,
             'TELEMETRY_MAVLINK': 8,
+            //'MSP_CLIENT': 9,
+            'TELEMETRY_IBUS': 10,
         },
 
     read: function (readInfo) {

--- a/tabs/ports.js
+++ b/tabs/ports.js
@@ -30,6 +30,11 @@ TABS.ports.initialize = function (callback, scrollPosition) {
         functionRules.push(mavlinkFunctionRule);
     }
 
+    if (semver.gte(CONFIG.apiVersion, "1.22.0")) {
+        var iBusFunctionRule = {name: 'TELEMETRY_IBUS',    groups: ['telemetry'], sharableWith: ['msp'], notSharableWith: ['blackbox'], maxPorts: 1};
+        functionRules.push(iBusFunctionRule);
+    }
+
     for (var i = 0; i < functionRules.length; i++) {
         functionRules[i].displayName = chrome.i18n.getMessage('portsFunction_' + functionRules[i].name);
     }


### PR DESCRIPTION
Companion to https://github.com/cleanflight/cleanflight/pull/2415 adds a new telemetry mode in the ports tab.