### PR TITLE
Change the extension of blackbox saved files

### DIFF
--- a/js/backup_restore.js
+++ b/js/backup_restore.js
@@ -161,7 +161,7 @@ function configuration_backup(callback) {
     function save() {
         var chosenFileEntry = null;
 
-        var prefix = CONFIG.flightControllerIdentifier + '_backup';
+        var prefix = 'backup';
         var suffix = 'json';
 
         var filename = generateFilename(prefix, suffix);

--- a/main.js
+++ b/main.js
@@ -519,8 +519,13 @@ function generateFilename(prefix, suffix) {
     var date = new Date();
     var filename = prefix;
 
-    if (CONFIG && CONFIG.name && CONFIG.name.trim() !== '') {
-        filename = filename + '_' + CONFIG.name.trim().replace(' ', '_');
+    if (CONFIG) {
+        if (CONFIG.flightControllerIdentifier) {
+        	filename = CONFIG.flightControllerIdentifier + '_' + filename; 	
+        }
+        if(CONFIG.name && CONFIG.name.trim() !== '') {
+        	filename = filename + '_' + CONFIG.name.trim().replace(' ', '_');
+        }
     }
 
     filename = filename + '_' + date.getFullYear()

--- a/tabs/logging.js
+++ b/tabs/logging.js
@@ -230,7 +230,7 @@ TABS.logging.initialize = function (callback) {
 
     function prepare_file() {
         
-        var prefix = CONFIG.flightControllerIdentifier + '_log';
+        var prefix = 'log';
         var suffix = 'csv';
 
         var filename = generateFilename(prefix, suffix);

--- a/tabs/onboard_logging.js
+++ b/tabs/onboard_logging.js
@@ -392,8 +392,9 @@ TABS.onboard_logging.initialize = function (callback) {
     }
     
     function prepare_file(onComplete) {
-        var suffix = 'BFL';
+        
         var prefix = 'BLACKBOX_LOG';
+        var suffix = 'BBL';
 
         var filename = generateFilename(prefix, suffix);
 


### PR DESCRIPTION
This PR solves https://github.com/cleanflight/cleanflight-configurator/issues/453

The extension for saved files is `BFL` (BetaFlight Log). They must be `CFL` (CleanFlight Log) or use a unique file extension `BBL`  (BlackBox Log).

This PR uses `BBL` as extension, as suggested in the issue by @mikeller, but I can change it if to `CFL` if finally this is the preferred way (in this way, by the extension we can know what software has recorded the log).

@hydra what do you think?