### PR TITLE
Update OSD preview for Throttle and GPS speed to adjust to reality

### DIFF
--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -261,7 +261,7 @@ OSD.constants = {
       name: 'THROTTLE_POSITION',
       default_position: -9,
       positionable: true,
-      preview: FONT.symbol(SYM.THR) + FONT.symbol(SYM.THR1) + ' 69'
+      preview: FONT.symbol(SYM.THR) + FONT.symbol(SYM.THR1) + '69'
     },
     CPU_LOAD: {
       name: 'CPU_LOAD',
@@ -356,7 +356,7 @@ OSD.constants = {
       name: 'GPS_SPEED',
       default_position: -1,
       positionable: true,
-      preview: '40'
+      preview: '40K'
     },
     GPS_SATS: {
       name: 'GPS_SATS',


### PR DESCRIPTION
Remove space from throttle and added K to speed, to adjust to the way the real OSD shows this values.