### PR TITLE
Adjust peripherals mode name in failsafe tab

### DIFF
--- a/js/peripherals.js
+++ b/js/peripherals.js
@@ -1,0 +1,32 @@
+'use strict';
+
+    // return true if user has choose a special peripheral
+    function isPeripheralSelected(peripheralName) {
+        for (var portIndex = 0; portIndex < SERIAL_CONFIG.ports.length; portIndex++) {
+            var serialPort = SERIAL_CONFIG.ports[portIndex];
+            if (serialPort.functions.indexOf(peripheralName) >= 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Adjust the real name for a modeId. Useful if it belongs to a peripheral
+    function adjustBoxNameIfPeripheralWithModeID(modeId, defaultName) {
+        if (isPeripheralSelected("RUNCAM_SPLIT_CONTROL")) {
+            switch (modeId) {
+                case 32: // BOXCAMERA1
+                    return "CAMERA WI-FI";
+                case 33: // BOXCAMERA2
+                    return "CAMERA POWER";
+                case 34: // BOXCAMERA3
+                    return "CAMERA CHANGE MODE";
+                default:
+                    return defaultName;
+            }
+        } 
+        
+        return defaultName;
+        
+    }

--- a/main.html
+++ b/main.html
@@ -65,6 +65,7 @@
     <script type="text/javascript" src="./js/msp.js"></script>
     <script type="text/javascript" src="./js/msp/MSPHelper.js"></script>
     <script type="text/javascript" src="./js/backup_restore.js"></script>
+    <script type="text/javascript" src="./js/peripherals.js"></script>
     <script type="text/javascript" src="./js/protocols/stm32.js"></script>
     <script type="text/javascript" src="./js/protocols/stm32usbdfu.js"></script>
     <script type="text/javascript" src="./js/localization.js"></script>

--- a/tabs/auxiliary.js
+++ b/tabs/auxiliary.js
@@ -29,40 +29,13 @@ TABS.auxiliary.initialize = function (callback) {
 
     MSP.send_message(MSPCodes.MSP_BOXNAMES, false, false, get_mode_ranges);
 
-    // return true if user has choose a special peripheral
-    function isPeripheralSelected(peripheralName) {
-        for (var portIndex = 0; portIndex < SERIAL_CONFIG.ports.length; portIndex++) {
-            var serialPort = SERIAL_CONFIG.ports[portIndex];
-            if (serialPort.functions.indexOf(peripheralName) >= 0) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    function adjustRunCamSplitBoxNameWithModeID(modeId, originalModeName) {
-        switch (modeId) {
-            case 32: // BOXCAMERA1
-                return "CAMERA WI-FI";
-            case 33: // BOXCAMERA2
-                return "CAMERA POWER";
-            case 34: // BOXCAMERA3
-                return "CAMERA CHANGE MODE"
-            default:
-                return originalModeName;
-        }
-    }
-
     function createMode(modeIndex, modeId) {
         var modeTemplate = $('#tab-auxiliary-templates .mode');
         var newMode = modeTemplate.clone();
         
         var modeName = AUX_CONFIG[modeIndex];
-        // if user choose the runcam split at peripheral column, then adjust the boxname(BOXCAMERA1, BOXCAMERA2, BOXCAMERA3)
-        if (isPeripheralSelected("RUNCAM_SPLIT_CONTROL")) {
-            modeName = adjustRunCamSplitBoxNameWithModeID(modeId, modeName);
-        }
+        // Adjust the name of the box if a peripheral is selected
+        modeName = adjustBoxNameIfPeripheralWithModeID(modeId, modeName);
 
         $(newMode).attr('id', 'mode-' + modeIndex);
         $(newMode).find('.name').text(modeName);

--- a/tabs/failsafe.js
+++ b/tabs/failsafe.js
@@ -30,7 +30,11 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
     }
 
     function get_box_ids() {
-        MSP.send_message(MSPCodes.MSP_BOXIDS, false, false, get_rc_data);
+        MSP.send_message(MSPCodes.MSP_BOXIDS, false, false, get_ports_config);
+    }
+
+    function get_ports_config() {
+        MSP.send_message(MSPCodes.MSP_CF_SERIAL_CONFIG, false, false, get_rc_data);
     }
 
     function get_rc_data() {
@@ -101,7 +105,11 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
                     continue; // invalid!
                 }
 
-                auxAssignment[modeRange.auxChannelIndex] += "<span class=\"modename\">" + AUX_CONFIG[modeIndex] + "</span>";
+                // Search for the real name if it belongs to a peripheral
+                var modeName = AUX_CONFIG[modeIndex];                
+                modeName = adjustBoxNameIfPeripheralWithModeID(modeId, modeName);
+
+                auxAssignment[modeRange.auxChannelIndex] += "<span class=\"modename\">" + modeName + "</span>";
             }
         }
 


### PR DESCRIPTION
The failsafe tab does not adjust the real name of the MODE for peripherals. Only the MODES tab do it. This PR solves this.

Now the only MODE NAMES for peripherals are from RC Split (thanks @azolyoung).

I've moved the functions for peripherals to a new file, I don't know if there's better other place for it. Suggestions welcome.