### PR TITLE
remove trailing "," which causes error in GUI

### DIFF
--- a/js/Features.js
+++ b/js/Features.js
@@ -72,7 +72,7 @@ var Features = function (config) {
 
         if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
             features.push(
-                {bit: 18, group: 'other', name: 'OSD'},
+                {bit: 18, group: 'other', name: 'OSD'}
             );
         }
 


### PR DESCRIPTION
Resolves an issue where GUI fails to load (falling back to CLI) caused by syntax error because of the comma after the last item in the array.